### PR TITLE
adding seedable protocol to Squirrel3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,15 +7,18 @@ let package = Package(
     products: [
         .library(
             name: "Squirrel3",
-            targets: ["Squirrel3"]),
+            targets: ["Squirrel3"]
+        ),
     ],
     targets: [
         .target(
             name: "Squirrel3",
-            dependencies: ["CSquirrel"]),
+            dependencies: ["CSquirrel"]
+        ),
         .target(name: "CSquirrel"),
         .testTarget(
             name: "Squirrel3Tests",
-            dependencies: ["Squirrel3"]),
+            dependencies: ["Squirrel3"]
+        ),
     ]
 )

--- a/Sources/Squirrel3/SeededRandomNumberGenerator.swift
+++ b/Sources/Squirrel3/SeededRandomNumberGenerator.swift
@@ -1,0 +1,23 @@
+//
+//  SeededPseudoRandomNumberGenerator.swift
+//
+//  Created by Joseph Heck on 1/1/22.
+//
+
+import Foundation
+
+/// A type that represents a random number generator that you can seed.
+///
+/// The protocol includes an adjustable position property that represents the current location within the space of random numbers that the random number generates.
+/// The seed value is preserved and unchanged, allowing the seeded random number generator to be interrogated and replicated.
+/// When applied to a pseudo-random number generator, with a given seed and position, the next random number should be  completely deterministic.
+public protocol SeededRandomNumberGenerator: RandomNumberGenerator {
+    /// The seed for the random number generator.
+    var seed: UInt64 { get }
+
+    /// An adjustable position from which influences the next random value that the seed generates.
+    var position: UInt64 { get set }
+
+    /// Creates a new pseudo-random number generator with the seed you provide.
+    init(seed: UInt64)
+}

--- a/Sources/Squirrel3/Squirrel3.swift
+++ b/Sources/Squirrel3/Squirrel3.swift
@@ -1,22 +1,25 @@
-import Foundation
 import CSquirrel
+import Foundation
 // This RNG function uses Squirrel Eiserloh's hash function to generate "random" numbers.
 
-
 /// A Pseudo-random number generator that deterministically creates random numbers based on the seed you provide.
-public struct PRNG: RandomNumberGenerator {
+public struct PRNG: SeededRandomNumberGenerator {
+    /// The current position of the pseudo-random number generator.
+    public var position: UInt64
+
     /// The seed for the pseudo-random number generator.
-    public var seed: UInt64
-    
+    public let seed: UInt64
+
     /// Creates a new pseudo-random number generator.
     /// - Parameter seed: An unsigned integer seed value for the generator.
     public init(seed: UInt64) {
         self.seed = seed
+        position = seed
     }
-    
+
     /// Returns the next random UInt64 value.
     public mutating func next() -> UInt64 {
-        seed = Squirrel3(seed)
-        return seed
+        position = Squirrel3(position)
+        return position
     }
 }


### PR DESCRIPTION
 - and making the seed constant for easier retrieval and re-creation
 - also cleaned everything up a bit with a run of `swiftformat .`